### PR TITLE
observe how many observables you have created

### DIFF
--- a/debug.js
+++ b/debug.js
@@ -1,0 +1,51 @@
+
+var Mutant = require('./')
+var tape = require('tape')
+var cache = require('module')._cache
+
+var counts = {}
+var MUTANTS = module.exports = Mutant.Value()
+
+for(var k in cache) (function (module) {
+  if(
+    module.id.indexOf(__dirname) === 0 &&
+    !~module.id.substring(__dirname.length).indexOf('node_modules')
+  ) {
+    var name = module.id.substring(__dirname.length+1)
+    var fn = module.exports
+    if('function' == typeof fn) {
+      module.exports = function () {
+        var args = [].slice.call(arguments)
+        counts[name] = (counts[name] || 0) + 1
+        MUTANTS.set(counts)
+        return fn.apply(this, args)
+      }
+      for(var k in Mutant)
+        if(Mutant[k] === fn) {
+          Mutant[k] = module.exports
+          break
+        }
+      }
+  }
+})(cache[k])
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
So, I was wondering about performance stuff, and I made a script to count how many of which types of observables were being created.
How better to observe observables than with an observable?

to use this, do

``` js
MUTANTS = require('mutants/debug')
```
at the top of your program. Then you can access the `MUTANTS` global in the dev tools.
You could also render it in html and get a live updating view of the most used observables.

Putting this here for discussion more than a serious PR, still need to play with this a bit to see if it's useful.