### PR TITLE
html-element: add intersectionBindingViewport option to only bind elements in viewport

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Requires an environment that supports:
   - `element.classList`
   - `MutationObserver` (optional, only for root `html-element` binding support)
   - ES5 arrays (`Array.prototype.forEach`, etc)
+  - `IntersectionObserver` (optional, only when using `intersectionBindingViewport` attribute on elements)
   - `Array.prototype.includes`
 
 ## Example
@@ -356,11 +357,24 @@ Stuff that are exit hatches / sinks / make changes in the real world.
 
 ### HtmlElement / h
 
+```js
+var textAlign = Value('center')
+var someText = Value('some text')
+var element = h('div', {style: {'text-align': textAlign}}, [
+  h('p.text', someText),
+  h('p.text', [
+    'Text with ', h('strong', 'formatting'), ' and a ', h('a', {href: '/url'}, 'hyperlink')
+  ]),
+])
+```
+
 A fancy wrapper around `document.createElement()` that allows you to create DOM elements (entire trees if needed) without setting lots of properties or writing html. It just returns plain old DOM elements that can be added directly to the DOM.
 
-This is basically just [hyperscript](https://github.com/dominictarr/hyperscript) with a bunch of small tweaks that make it a lot more memory friendly. I've also enhanced the binding ability.
+This is basically just [hyperscript](https://github.com/dominictarr/hyperscript) with a bunch of small tweaks and enhanced binding ability.
 
-In hyperscript you can add [observables](https://github.com/dominictarr/observable) as properties and when the observable value changes, the DOM magically updates. You can also return a DOM element. But in mutant, I've gone an extra step further and allow observables to return **multiple DOM elements**. I've also made "cleanup" (unbinding from events to free memory) automatic. It's a lot like pull streams: the DOM acts as a sink. **If an element created by mutant is not in the DOM, it doesn't listen to its observable properties.** It only resolves them once it is added, and if it is removed unlistens again.
+You can add observables as properties and when the observable value changes, the DOM magically updates. You can also return **one or more DOM elements**. Cleanup is automatic (when removed from DOM using `MutationObserver`). It's a lot like pull streams: the DOM acts as a sink. **If an element created by mutant is not in the DOM, it doesn't listen to its observable properties.** It only resolves them once it is added, and if it is removed unlistens again.
+
+You can also specify an `intersectionBindingViewport` on scrolling elements if you would like the elements to only be bound (live) when they are in the viewport. You can specify `true` or `{rootMargin}`. See [Intersection Observer API - rootMargin](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/rootMargin) for details.
 
 
 ### watchAll

--- a/html-element.js
+++ b/html-element.js
@@ -42,7 +42,8 @@ function Element (document, namespace, tagName, properties, children) {
   var data = {
     targets: new Map(),
     observing: false,
-    bindings: []
+    bindings: [],
+    hookBindings: []
   }
 
   if ('intersectionBindingViewport' in properties) {
@@ -284,6 +285,7 @@ function rebind (node) {
       } else {
         data.bindings.forEach(invokeBind)
       }
+      data.hookBindings.forEach(invokeBind)
     }
   }
 }
@@ -298,6 +300,7 @@ function unbind (node) {
         intersectionObserver.unobserve(node)
       }
       data.bindings.forEach(invokeUnbind)
+      data.hookBindings.forEach(invokeUnbind)
     }
   }
 }
@@ -306,7 +309,7 @@ function isBound (node) {
   if (node.nodeType === 1) {
     var data = caches.get(node)
     if (data) {
-      return data.observing || data.bindings.some(getBound)
+      return data.observing || data.bindings.some(getBound) || data.hookBindings.some(getBound)
     }
   }
 }

--- a/html-element.js
+++ b/html-element.js
@@ -41,7 +41,22 @@ function Element (document, namespace, tagName, properties, children) {
 
   var data = {
     targets: new Map(),
+    observing: false,
     bindings: []
+  }
+
+  if ('intersectionBindingViewport' in properties) {
+    var options = properties.intersectionBindingViewport
+    delete properties.intersectionBindingViewport
+
+    if (options && global.IntersectionObserver) {
+      node.__mutantIntersectionBindingViewport = true
+      data.intersectionObserver = new global.IntersectionObserver(onIntersection, {
+        root: node,
+        rootMargin: options.rootMargin || '0px',
+        threshold: [0, 0.1]
+      })
+    }
   }
 
   caches.set(node, data)
@@ -111,12 +126,61 @@ function onMutate (changes) {
   changes.forEach(handleChange)
 }
 
+function onIntersection (changes) {
+  changes.forEach(handleIntersect)
+}
+
+function handleIntersect (change) {
+  if (change.isIntersecting) {
+    if (change.intersectionRatio >= 0.1) {
+      enterViewport(change.target)
+    }
+  } else {
+    exitViewport(change.target)
+  }
+}
+
 function getRootNode (el) {
   var element = el
   while (element.parentNode) {
     element = element.parentNode
   }
   return element
+}
+
+function getIntersectionObserver (el) {
+  var element = el
+  while (element.parentNode) {
+    element = element.parentNode
+    if (element.__mutantIntersectionBindingViewport) {
+      var data = caches.get(element)
+      if (data) {
+        return data.intersectionObserver
+      }
+    }
+  }
+}
+
+function enterViewport (node) {
+  if (node.nodeType === 1) {
+    var data = caches.get(node)
+    if (data) {
+      if (data.observing) {
+        data.bindings.forEach(invokeBind)
+      }
+    }
+  }
+}
+
+function exitViewport (node) {
+  if (node.nodeType === 1) {
+    var data = caches.get(node)
+    if (data) {
+      if (data.observing) {
+        data.bindings.forEach(invokeUnbind)
+      }
+    }
+  }
 }
 
 function handleChange (change) {
@@ -213,7 +277,13 @@ function rebind (node) {
   if (node.nodeType === 1) {
     var data = caches.get(node)
     if (data) {
-      data.bindings.forEach(invokeBind)
+      var intersectionObserver = getIntersectionObserver(node)
+      if (!data.observing && intersectionObserver) {
+        data.observing = true
+        intersectionObserver.observe(node)
+      } else {
+        data.bindings.forEach(invokeBind)
+      }
     }
   }
 }
@@ -222,6 +292,11 @@ function unbind (node) {
   if (node.nodeType === 1) {
     var data = caches.get(node)
     if (data) {
+      var intersectionObserver = getIntersectionObserver(node)
+      if (intersectionObserver && data.observing) {
+        data.observing = false
+        intersectionObserver.unobserve(node)
+      }
       data.bindings.forEach(invokeUnbind)
     }
   }
@@ -231,7 +306,7 @@ function isBound (node) {
   if (node.nodeType === 1) {
     var data = caches.get(node)
     if (data) {
-      return data.bindings.some(getBound)
+      return data.observing || data.bindings.some(getBound)
     }
   }
 }

--- a/lib/apply-properties.js
+++ b/lib/apply-properties.js
@@ -28,7 +28,8 @@ function applyProperties (target, properties, data) {
       var value = resolve(valueOrObs)
       if (Array.isArray(value)) {
         value.forEach(function (v) {
-          data.bindings.push(new HookBinding(v, target))
+          // hookBindings are treated the same as bindings, except that they bypass intersectionBindingViewport
+          data.hookBindings.push(new HookBinding(v, target))
         })
       }
     } else if (key === 'attributes') {


### PR DESCRIPTION
Apply this property to any element and it will create an [`IntersectionObserver`](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) that will only bind elements to observables that are in the viewport.

**This can allow for optimisation of memory usage and data observers, and improve refresh performance when used with infinitely loading scrollers.**

Currently [being used in patchwork](https://github.com/ssbc/patchwork/commit/ff70fe16402981ee8070630f5c8dce882b364d70).

A little bit experimental right now, but gonna run it for a while and see what comes up. Yes, there are no tests. I really should figure out how to write some.

See also: ssbc/patchwork#858

@mixmix @ahdinosaur you might be interested in this!